### PR TITLE
Replicate players

### DIFF
--- a/entities/block.go
+++ b/entities/block.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"github.com/go-gl/mathgl/mgl64"
 	"github.com/kkevinchou/kito/components"
+	"github.com/kkevinchou/kito/types"
 )
 
 func NewBlock() *EntityImpl {
@@ -21,6 +22,7 @@ func NewBlock() *EntityImpl {
 
 	entity := NewEntity(
 		"block",
+		types.EntityTypeBlock,
 		components.NewComponentContainer(
 			transformComponent,
 			renderComponent,

--- a/entities/bob.go
+++ b/entities/bob.go
@@ -63,6 +63,7 @@ func NewBob(position mgl64.Vec3) *EntityImpl {
 
 	entity := NewEntity(
 		"bob",
+		types.EntityTypeBob,
 		components.NewComponentContainer(entityComponents...),
 	)
 

--- a/entities/camera.go
+++ b/entities/camera.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"github.com/go-gl/mathgl/mgl64"
 	"github.com/kkevinchou/kito/components"
+	"github.com/kkevinchou/kito/types"
 )
 
 func NewThirdPersonCamera(positionOffset mgl64.Vec3, view mgl64.Vec2, followTargetEntityID int) *EntityImpl {
@@ -22,6 +23,7 @@ func NewThirdPersonCamera(positionOffset mgl64.Vec3, view mgl64.Vec2, followTarg
 
 	entity := NewEntity(
 		"camera",
+		types.EntityTypeCamera,
 		components.NewComponentContainer(
 			&components.NetworkComponent{},
 			&components.CameraComponent{},

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -3,25 +3,29 @@ package entities
 import (
 	"github.com/kkevinchou/kito/components"
 	"github.com/kkevinchou/kito/settings"
+	"github.com/kkevinchou/kito/types"
 )
 
 var idCounter int = settings.EntityIDStart
 
 type Entity interface {
 	GetID() int
+	Type() types.EntityType
 	GetName() string
 	GetComponentContainer() *components.ComponentContainer
 }
 
 type EntityImpl struct {
 	ID                 int
+	entityType         types.EntityType
 	Name               string
 	ComponentContainer *components.ComponentContainer
 }
 
-func NewEntity(name string, componentContainer *components.ComponentContainer) *EntityImpl {
+func NewEntity(name string, entityType types.EntityType, componentContainer *components.ComponentContainer) *EntityImpl {
 	e := EntityImpl{
 		ID:                 idCounter,
+		entityType:         entityType,
 		Name:               name,
 		ComponentContainer: componentContainer,
 	}
@@ -39,4 +43,8 @@ func (e *EntityImpl) GetName() string {
 
 func (e *EntityImpl) GetID() int {
 	return e.ID
+}
+
+func (e *EntityImpl) Type() types.EntityType {
+	return e.entityType
 }

--- a/entities/types.go
+++ b/entities/types.go
@@ -1,1 +1,0 @@
-package entities

--- a/events/createentity.go
+++ b/events/createentity.go
@@ -1,0 +1,22 @@
+package events
+
+import "encoding/json"
+
+type EntityType int
+
+const (
+	EntityTypeBob EntityType = iota
+)
+
+type CreateEntityEvent struct {
+	EntityType EntityType `json:"entity_type"`
+	EntityID   int        `json:"entity_id"`
+}
+
+func (e *CreateEntityEvent) Serialize() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+func (e *CreateEntityEvent) Type() EventType {
+	return EventTypeCreateEntity
+}

--- a/events/createentity.go
+++ b/events/createentity.go
@@ -1,16 +1,14 @@
 package events
 
-import "encoding/json"
+import (
+	"encoding/json"
 
-type EntityType int
-
-const (
-	EntityTypeBob EntityType = iota
+	"github.com/kkevinchou/kito/types"
 )
 
 type CreateEntityEvent struct {
-	EntityType EntityType `json:"entity_type"`
-	EntityID   int        `json:"entity_id"`
+	EntityType types.EntityType `json:"entity_type"`
+	EntityID   int              `json:"entity_id"`
 }
 
 func (e *CreateEntityEvent) Serialize() ([]byte, error) {
@@ -19,4 +17,8 @@ func (e *CreateEntityEvent) Serialize() ([]byte, error) {
 
 func (e *CreateEntityEvent) Type() EventType {
 	return EventTypeCreateEntity
+}
+
+func (e *CreateEntityEvent) TypeAsInt() int {
+	return int(EventTypeCreateEntity)
 }

--- a/events/events.go
+++ b/events/events.go
@@ -4,6 +4,7 @@ type EventType int
 
 type Event interface {
 	Type() EventType
+	TypeAsInt() int
 	Serialize() ([]byte, error)
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -1,0 +1,12 @@
+package events
+
+type EventType int
+
+type Event interface {
+	Type() EventType
+	Serialize() ([]byte, error)
+}
+
+const (
+	EventTypeCreateEntity EventType = iota
+)

--- a/lib/network/message.go
+++ b/lib/network/message.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"github.com/go-gl/mathgl/mgl64"
+	"github.com/kkevinchou/kito/events"
 	"github.com/kkevinchou/kito/lib/input"
 )
 
@@ -48,8 +49,14 @@ type EntitySnapshot struct {
 	Orientation mgl64.Quat
 }
 
+type SerializedEvent struct {
+	EventType events.EventType
+	Bytes     []byte
+}
+
 type GameStateSnapshotMessage struct {
 	Entities map[int]EntitySnapshot
+	Events   []SerializedEvent
 }
 
 type InputMessage struct {

--- a/lib/network/message.go
+++ b/lib/network/message.go
@@ -41,6 +41,7 @@ type AckCreatePlayerMessage struct {
 
 type EntitySnapshot struct {
 	ID          int
+	Type        int
 	Position    mgl64.Vec3
 	Orientation mgl64.Quat
 }
@@ -50,9 +51,15 @@ type Event struct {
 	Bytes []byte
 }
 
+type EventI interface {
+	TypeAsInt() int
+	Serialize() ([]byte, error)
+}
+
 type GameStateUpdateMessage struct {
 	Entities map[int]EntitySnapshot
 	Events   []Event
+	Events2  []EventI
 }
 
 type InputMessage struct {

--- a/lib/network/message.go
+++ b/lib/network/message.go
@@ -14,7 +14,7 @@ const (
 	MessageTypeReplication
 	MessageTypeCreatePlayer
 	MessageTypeAckCreatePlayer
-	MessageTypeGameStateSnapshot
+	MessageTypeGameStateUpdate
 )
 
 type Message struct {
@@ -39,23 +39,20 @@ type AckCreatePlayerMessage struct {
 	Orientation mgl64.Quat `json:"orientation"`
 }
 
-type ReplicationMessage struct {
-}
-
 type EntitySnapshot struct {
 	ID          int
 	Position    mgl64.Vec3
 	Orientation mgl64.Quat
 }
 
-type SerializedEvent struct {
+type Event struct {
 	Type  int
 	Bytes []byte
 }
 
-type GameStateSnapshotMessage struct {
+type GameStateUpdateMessage struct {
 	Entities map[int]EntitySnapshot
-	Events   []SerializedEvent
+	Events   []Event
 }
 
 type InputMessage struct {

--- a/lib/network/message.go
+++ b/lib/network/message.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"github.com/go-gl/mathgl/mgl64"
-	"github.com/kkevinchou/kito/events"
 	"github.com/kkevinchou/kito/lib/input"
 )
 
@@ -50,8 +49,8 @@ type EntitySnapshot struct {
 }
 
 type SerializedEvent struct {
-	EventType events.EventType
-	Bytes     []byte
+	Type  int
+	Bytes []byte
 }
 
 type GameStateSnapshotMessage struct {

--- a/managers/eventbroker/eventbroker.go
+++ b/managers/eventbroker/eventbroker.go
@@ -1,37 +1,33 @@
 package eventbroker
 
-type EventType int
-
-const (
-	EventCreatePlayer EventType = iota
-)
+import "github.com/kkevinchou/kito/events"
 
 type Observer interface {
-	Observe(eventType EventType, event interface{})
+	Observe(event events.Event)
 }
 
 type EventBroker interface {
-	Broadcast(eventType EventType, event interface{})
-	AddObserver(observer Observer, eventTypes []EventType)
+	Broadcast(event events.Event)
+	AddObserver(observer Observer, eventTypes []events.EventType)
 }
 
 type EventBrokerImpl struct {
-	observations map[EventType][]Observer
+	observations map[events.EventType][]Observer
 }
 
 func NewEventBroker() *EventBrokerImpl {
 	return &EventBrokerImpl{
-		observations: map[EventType][]Observer{},
+		observations: map[events.EventType][]Observer{},
 	}
 }
 
-func (e *EventBrokerImpl) Broadcast(eventType EventType, event interface{}) {
-	for _, observer := range e.observations[eventType] {
-		observer.Observe(eventType, event)
+func (e *EventBrokerImpl) Broadcast(event events.Event) {
+	for _, observer := range e.observations[event.Type()] {
+		observer.Observe(event)
 	}
 }
 
-func (e *EventBrokerImpl) AddObserver(observer Observer, eventTypes []EventType) {
+func (e *EventBrokerImpl) AddObserver(observer Observer, eventTypes []events.EventType) {
 	for _, eventType := range eventTypes {
 		e.observations[eventType] = append(e.observations[eventType], observer)
 	}

--- a/systems/base/base.go
+++ b/systems/base/base.go
@@ -1,6 +1,6 @@
 package base
 
-import "github.com/kkevinchou/kito/managers/eventbroker"
+import "github.com/kkevinchou/kito/events"
 
 type BaseSystem struct {
 }
@@ -9,6 +9,6 @@ func NewBaseSystem() *BaseSystem {
 	return &BaseSystem{}
 }
 
-func (b *BaseSystem) Observe(eventType eventbroker.EventType, event interface{}) {
+func (b *BaseSystem) Observe(event events.Event) {
 
 }

--- a/systems/charactercontroller/charactercontroller.go
+++ b/systems/charactercontroller/charactercontroller.go
@@ -43,7 +43,7 @@ func (s *CharacterControllerSystem) RegisterEntity(entity entities.Entity) {
 
 func (s *CharacterControllerSystem) Update(delta time.Duration) {
 	if utils.IsClient() {
-		return
+		// return
 	}
 
 	d := directory.GetDirectory()

--- a/systems/networkdispatch/clientmessagehandler.go
+++ b/systems/networkdispatch/clientmessagehandler.go
@@ -1,0 +1,86 @@
+package networkdispatch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-gl/mathgl/mgl64"
+	"github.com/kkevinchou/kito/entities"
+	"github.com/kkevinchou/kito/events"
+	"github.com/kkevinchou/kito/lib/network"
+	"github.com/kkevinchou/kito/settings"
+)
+
+func ClientMessageHandler(world World, message *network.Message) {
+	if message.MessageType == network.MessageTypeGameStateUpdate {
+		handleGameStateUpdate(message, world)
+	} else if message.MessageType == network.MessageTypeAckCreatePlayer {
+		handleAckCreatePlayer(message, world)
+	} else {
+		fmt.Println("unknown message type:", message.MessageType, string(message.Body))
+	}
+}
+
+func handleGameStateUpdate(message *network.Message, world World) {
+	singleton := world.GetSingleton()
+	var gameStateupdate network.GameStateUpdateMessage
+	err := json.Unmarshal(message.Body, &gameStateupdate)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, entitySnapshot := range gameStateupdate.Entities {
+		entity, err := world.GetEntityByID(entitySnapshot.ID)
+		if err != nil {
+			continue
+		}
+
+		cc := entity.GetComponentContainer()
+		cc.TransformComponent.Position = entitySnapshot.Position
+		cc.TransformComponent.Orientation = entitySnapshot.Orientation
+	}
+
+	for _, event := range gameStateupdate.Events {
+		if events.EventType(event.Type) == events.EventTypeCreateEntity {
+			var realEvent events.CreateEntityEvent
+			json.Unmarshal(event.Bytes, &realEvent)
+
+			if realEvent.EntityType == events.EntityTypeBob {
+				if realEvent.EntityID == singleton.PlayerID {
+					// TODO: skip this is event as its the creation event of the original player.
+					// In the future, the server should simply not send this message to the player
+					continue
+				}
+				bob := entities.NewBob(mgl64.Vec3{})
+				bob.ID = realEvent.EntityID
+				world.RegisterEntities([]entities.Entity{bob})
+			}
+		}
+	}
+}
+
+func handleAckCreatePlayer(message *network.Message, world World) {
+	subMessage := &network.AckCreatePlayerMessage{}
+	err := json.Unmarshal(message.Body, subMessage)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	singleton := world.GetSingleton()
+	singleton.PlayerID = subMessage.ID
+	singleton.CameraID = subMessage.CameraID
+
+	bob := entities.NewBob(mgl64.Vec3{})
+	bob.ID = subMessage.ID
+
+	camera := entities.NewThirdPersonCamera(settings.CameraStartPosition, settings.CameraStartView, bob.GetID())
+	camera.ID = subMessage.CameraID
+
+	bob.GetComponentContainer().ThirdPersonControllerComponent.CameraID = camera.GetID()
+
+	world.RegisterEntities([]entities.Entity{
+		bob,
+		camera,
+	})
+}

--- a/systems/networkdispatch/networkdispatch.go
+++ b/systems/networkdispatch/networkdispatch.go
@@ -37,10 +37,6 @@ func NewNetworkDispatchSystem(world World) *NetworkDispatchSystem {
 		messageFetcher: defaultMessageFetcher,
 		messageHandler: defaultMessageHandler,
 	}
-	eventBroker := world.GetEventBroker()
-	eventBroker.AddObserver(networkDispatchSystem, []eventbroker.EventType{
-		eventbroker.EventCreatePlayer,
-	})
 
 	return networkDispatchSystem
 }

--- a/systems/networkdispatch/servermessagehandler.go
+++ b/systems/networkdispatch/servermessagehandler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kkevinchou/kito/events"
 	"github.com/kkevinchou/kito/lib/network"
 	"github.com/kkevinchou/kito/managers/player"
+	"github.com/kkevinchou/kito/types"
 )
 
 type MessageHandler func(world World, message *network.Message)
@@ -75,7 +76,7 @@ func handleCreatePlayer(player *player.Player, message *network.Message, world W
 	fmt.Println("Sent entity ack creation message")
 
 	event := &events.CreateEntityEvent{
-		EntityType: events.EntityTypeBob,
+		EntityType: types.EntityTypeBob,
 		EntityID:   bob.GetID(),
 	}
 	world.GetEventBroker().Broadcast(event)

--- a/systems/networkupdate/networkupdate.go
+++ b/systems/networkupdate/networkupdate.go
@@ -69,12 +69,12 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 
 	s.elapsedFrames %= commandFramesPerUpdate
 
-	snapshot := &network.GameStateSnapshotMessage{
+	gameStateUpdate := &network.GameStateUpdateMessage{
 		Entities: map[int]network.EntitySnapshot{},
 	}
 
 	for _, entity := range s.entities {
-		snapshot.Entities[entity.GetID()] = constructEntitySnapshot(entity)
+		gameStateUpdate.Entities[entity.GetID()] = constructEntitySnapshot(entity)
 	}
 
 	for _, event := range s.events {
@@ -84,15 +84,15 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 			continue
 		}
 
-		serializedEvent := network.SerializedEvent{Type: int(event.Type()), Bytes: bytes}
-		snapshot.Events = append(snapshot.Events, serializedEvent)
+		serializedEvent := network.Event{Type: int(event.Type()), Bytes: bytes}
+		gameStateUpdate.Events = append(gameStateUpdate.Events, serializedEvent)
 	}
 
 	d := directory.GetDirectory()
 	playerManager := d.PlayerManager()
 
 	for _, player := range playerManager.GetPlayers() {
-		player.Client.SendMessage(network.MessageTypeGameStateSnapshot, snapshot)
+		player.Client.SendMessage(network.MessageTypeGameStateUpdate, gameStateUpdate)
 	}
 }
 

--- a/systems/networkupdate/networkupdate.go
+++ b/systems/networkupdate/networkupdate.go
@@ -1,11 +1,14 @@
 package networkupdate
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kkevinchou/kito/directory"
 	"github.com/kkevinchou/kito/entities"
+	"github.com/kkevinchou/kito/events"
 	"github.com/kkevinchou/kito/lib/network"
+	"github.com/kkevinchou/kito/managers/eventbroker"
 	"github.com/kkevinchou/kito/systems/base"
 )
 
@@ -15,6 +18,7 @@ const (
 
 type World interface {
 	RegisterEntities([]entities.Entity)
+	GetEventBroker() eventbroker.EventBroker
 }
 
 type NetworkUpdateSystem struct {
@@ -22,12 +26,26 @@ type NetworkUpdateSystem struct {
 	world         World
 	entities      []entities.Entity
 	elapsedFrames int
+	events        []events.Event
 }
 
 func NewNetworkUpdateSystem(world World) *NetworkUpdateSystem {
-	return &NetworkUpdateSystem{
+	networkUpdateSystem := &NetworkUpdateSystem{
 		BaseSystem: &base.BaseSystem{},
 		world:      world,
+	}
+
+	eventBroker := world.GetEventBroker()
+	eventBroker.AddObserver(networkUpdateSystem, []events.EventType{
+		events.EventTypeCreateEntity,
+	})
+
+	return networkUpdateSystem
+}
+
+func (s *NetworkUpdateSystem) Observe(event events.Event) {
+	if event.Type() == events.EventTypeCreateEntity {
+		s.events = append(s.events, event)
 	}
 }
 
@@ -45,6 +63,10 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 		return
 	}
 
+	// TODO: perhaps it's better to have a stack of events that we pop off so we don't accidentally lose
+	// events?
+	defer s.clearEvents()
+
 	s.elapsedFrames %= commandFramesPerUpdate
 
 	snapshot := &network.GameStateSnapshotMessage{
@@ -55,12 +77,27 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 		snapshot.Entities[entity.GetID()] = constructEntitySnapshot(entity)
 	}
 
+	for _, event := range s.events {
+		bytes, err := event.Serialize()
+		if err != nil {
+			fmt.Println("failed to serial event", err)
+			continue
+		}
+
+		serializedEvent := network.SerializedEvent{EventType: event.Type(), Bytes: bytes}
+		snapshot.Events = append(snapshot.Events, serializedEvent)
+	}
+
 	d := directory.GetDirectory()
 	playerManager := d.PlayerManager()
 
 	for _, player := range playerManager.GetPlayers() {
 		player.Client.SendMessage(network.MessageTypeGameStateSnapshot, snapshot)
 	}
+}
+
+func (s *NetworkUpdateSystem) clearEvents() {
+	s.events = []events.Event{}
 }
 
 func constructEntitySnapshot(entity entities.Entity) network.EntitySnapshot {

--- a/systems/networkupdate/networkupdate.go
+++ b/systems/networkupdate/networkupdate.go
@@ -84,7 +84,7 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 			continue
 		}
 
-		serializedEvent := network.SerializedEvent{EventType: event.Type(), Bytes: bytes}
+		serializedEvent := network.SerializedEvent{Type: int(event.Type()), Bytes: bytes}
 		snapshot.Events = append(snapshot.Events, serializedEvent)
 	}
 

--- a/systems/networkupdate/networkupdate.go
+++ b/systems/networkupdate/networkupdate.go
@@ -80,7 +80,7 @@ func (s *NetworkUpdateSystem) Update(delta time.Duration) {
 	for _, event := range s.events {
 		bytes, err := event.Serialize()
 		if err != nil {
-			fmt.Println("failed to serial event", err)
+			fmt.Println("failed to serialize event", err)
 			continue
 		}
 
@@ -105,6 +105,7 @@ func constructEntitySnapshot(entity entities.Entity) network.EntitySnapshot {
 
 	return network.EntitySnapshot{
 		ID:          entity.GetID(),
+		Type:        int(entity.Type()),
 		Position:    componentContainer.TransformComponent.Position,
 		Orientation: componentContainer.TransformComponent.Orientation,
 	}

--- a/types/entities.go
+++ b/types/entities.go
@@ -1,0 +1,9 @@
+package types
+
+type EntityType int
+
+const (
+	EntityTypeBob EntityType = iota
+	EntityTypeBlock
+	EntityTypeCamera
+)


### PR DESCRIPTION
* added entity types
* added support for events to allow entity creation, currently this code is unused and instead relies on entity snapshots. If an entity that the snapshot references doesn't exist, it is created. only Bob support for now