### PR TITLE
Server reconciliation

### DIFF
--- a/kito/commandframe/commandframe.go
+++ b/kito/commandframe/commandframe.go
@@ -67,11 +67,6 @@ func (h *CommandFrameHistory) ClearUntilFrameNumber(frameNumber int) {
 	h.CommandFrames = h.CommandFrames[frameNumber-startFrameNumber:]
 }
 
-// func (h *CommandFrameHistory) PopUntilFrameNumberInclusive(frameNumber int) {
-// 	startFrameNumber := h.CommandFrames[0].FrameNumber
-// 	h.CommandFrames = h.CommandFrames[frameNumber-startFrameNumber:]
-// }
-
 func (h *CommandFrameHistory) ClearFrames() {
 	h.CommandFrames = []CommandFrame{}
 }

--- a/kito/commandframe/commandframe.go
+++ b/kito/commandframe/commandframe.go
@@ -21,7 +21,6 @@ type CommandFrame struct {
 
 type CommandFrameHistory struct {
 	CommandFrames []CommandFrame
-	ReadOffset    int
 }
 
 func NewCommandFrameHistory() *CommandFrameHistory {
@@ -44,23 +43,35 @@ func (h *CommandFrameHistory) AddCommandFrame(frameNumber int, frameInput input.
 	}
 
 	h.CommandFrames = append(h.CommandFrames, cf)
-
-	// this handles the initial client startup phase where a command frame goes buy without recording a command frame.
-	// this is due to the player not existing yet. there's probably a cleaner way to handle this
-	if len(h.CommandFrames) == 1 {
-		h.ReadOffset = frameNumber
-	}
 }
 
 func (h *CommandFrameHistory) GetCommandFrame(frameNumber int) *CommandFrame {
-	if frameNumber-h.ReadOffset >= len(h.CommandFrames) {
+	if len(h.CommandFrames) == 0 {
 		return nil
 	}
-	return &h.CommandFrames[frameNumber-h.ReadOffset]
+
+	startFrameNumber := h.CommandFrames[0].FrameNumber
+	if frameNumber-startFrameNumber >= len(h.CommandFrames) {
+		return nil
+	}
+
+	return &h.CommandFrames[frameNumber-startFrameNumber]
 }
 
 func (h *CommandFrameHistory) ClearUntilFrameNumber(frameNumber int) {
-	// fmt.Println(frameNumber-h.ReadOffset, len(h.CommandFrames))
-	h.CommandFrames = h.CommandFrames[frameNumber-h.ReadOffset:]
-	h.ReadOffset = frameNumber
+	if len(h.CommandFrames) == 0 {
+		return
+	}
+
+	startFrameNumber := h.CommandFrames[0].FrameNumber
+	h.CommandFrames = h.CommandFrames[frameNumber-startFrameNumber:]
+}
+
+// func (h *CommandFrameHistory) PopUntilFrameNumberInclusive(frameNumber int) {
+// 	startFrameNumber := h.CommandFrames[0].FrameNumber
+// 	h.CommandFrames = h.CommandFrames[frameNumber-startFrameNumber:]
+// }
+
+func (h *CommandFrameHistory) ClearFrames() {
+	h.CommandFrames = []CommandFrame{}
 }

--- a/kito/kito.go
+++ b/kito/kito.go
@@ -105,6 +105,13 @@ func (g *Game) GetEntityByID(id int) (entities.Entity, error) {
 	return nil, fmt.Errorf("%sfailed to find entity with ID %d", string(stack), id)
 }
 
+func (g *Game) GetCamera() entities.Entity {
+	if entity, ok := g.entities[g.singleton.CameraID]; ok {
+		return entity
+	}
+	return nil
+}
+
 func (g *Game) RegisterEntities(entityList []entities.Entity) {
 	for _, entity := range entityList {
 		g.entities[entity.GetID()] = entity

--- a/kito/settings/settings.go
+++ b/kito/settings/settings.go
@@ -61,7 +61,7 @@ const (
 
 	// This is potentially overkill to avoiding absolutely no mispredictions on the client.
 	// The drawback of an input buffer is we now add a delay before we process user inputs.
-	MaxInputBufferCommandFrames int = 100 / int(MSPerCommandFrame)
+	MaxInputBufferCommandFrames int = 20 / int(MSPerCommandFrame)
 
 	MaxStateBufferCommandFrames int = 100 / int(MSPerCommandFrame)
 

--- a/kito/systems/charactercontroller/charactercontroller.go
+++ b/kito/systems/charactercontroller/charactercontroller.go
@@ -3,15 +3,11 @@ package charactercontroller
 import (
 	"time"
 
-	"github.com/go-gl/mathgl/mgl64"
 	"github.com/kkevinchou/kito/kito/directory"
 	"github.com/kkevinchou/kito/kito/entities"
 	"github.com/kkevinchou/kito/kito/singleton"
 	"github.com/kkevinchou/kito/kito/systems/base"
-	"github.com/kkevinchou/kito/kito/systems/common"
-	"github.com/kkevinchou/kito/kito/types"
-	"github.com/kkevinchou/kito/lib/input"
-	libutils "github.com/kkevinchou/kito/lib/libutils"
+	"github.com/kkevinchou/kito/kito/utils/controllerutils"
 )
 
 type World interface {
@@ -56,52 +52,6 @@ func (s *CharacterControllerSystem) Update(delta time.Duration) {
 		if err != nil {
 			continue
 		}
-		UpdateCharacterController(entity, camera, singleton.PlayerInput[player.ID])
-	}
-}
-
-func UpdateCharacterController(entity entities.Entity, camera entities.Entity, frameInput input.Input) {
-	componentContainer := entity.GetComponentContainer()
-	physicsComponent := componentContainer.PhysicsComponent
-
-	keyboardInput := frameInput.KeyboardInput
-
-	controlVector := common.GetControlVector(keyboardInput)
-
-	forwardVector := mgl64.Vec3{0, 0, -1}
-	rightVector := mgl64.Vec3{1, 0, 0}
-
-	if tpcComponent := componentContainer.ThirdPersonControllerComponent; tpcComponent != nil {
-		cameraComponentContainer := camera.GetComponentContainer()
-
-		forwardVector = cameraComponentContainer.TransformComponent.Orientation.Rotate(forwardVector)
-		forwardVector[1] = 0
-		forwardVector = forwardVector.Normalize()
-
-		rightVector = cameraComponentContainer.TransformComponent.Orientation.Rotate(rightVector)
-		rightVector[1] = 0
-		rightVector.Normalize()
-	}
-
-	forwardVector = forwardVector.Mul(controlVector.Z())
-	rightVector = rightVector.Mul(controlVector.X())
-	movementVector := forwardVector.Add(rightVector)
-	var moveSpeed float64 = 100
-
-	if !libutils.Vec3IsZero(movementVector) {
-		normalizedMovementVector := movementVector.Normalize()
-		impulse := types.Impulse{
-			Vector:    normalizedMovementVector.Mul(moveSpeed),
-			DecayRate: 5,
-		}
-		physicsComponent.ApplyImpulse("controllerMove", impulse)
-	}
-
-	if controlVector.Y() > 0 {
-		impulse := types.Impulse{
-			Vector:    mgl64.Vec3{0, 100, 0},
-			DecayRate: 1,
-		}
-		physicsComponent.ApplyImpulse("jumper", impulse)
+		controllerutils.UpdateCharacterController(entity, camera, singleton.PlayerInput[player.ID])
 	}
 }

--- a/kito/systems/networkdispatch/networkdispatch.go
+++ b/kito/systems/networkdispatch/networkdispatch.go
@@ -18,6 +18,7 @@ type World interface {
 	GetEventBroker() eventbroker.EventBroker
 	GetCommandFrameHistory() *commandframe.CommandFrameHistory
 	CommandFrame() int
+	GetCamera() entities.Entity
 }
 
 type NetworkDispatchSystem struct {

--- a/kito/systems/physics/physics.go
+++ b/kito/systems/physics/physics.go
@@ -5,16 +5,9 @@ import (
 
 	"github.com/kkevinchou/kito/kito/singleton"
 	"github.com/kkevinchou/kito/kito/systems/base"
-	"github.com/kkevinchou/kito/kito/utils"
-	"github.com/kkevinchou/kito/lib/libutils"
+	"github.com/kkevinchou/kito/kito/utils/physutils"
 
-	"github.com/go-gl/mathgl/mgl64"
 	"github.com/kkevinchou/kito/kito/entities"
-)
-
-const (
-	fullDecayThreshold = float64(0.05)
-	gravity            = float64(60)
 )
 
 type World interface {
@@ -44,75 +37,5 @@ func (s *PhysicsSystem) RegisterEntity(entity entities.Entity) {
 }
 
 func (s *PhysicsSystem) Update(delta time.Duration) {
-	PhysicsStep(delta, s.entities, s.world)
-}
-
-func PhysicsStep(delta time.Duration, entities []entities.Entity, world World) {
-	accelerationDueToGravity := mgl64.Vec3{0, -gravity, 0}
-
-	for _, entity := range entities {
-		// TODO: I don't like this here, probably a more elegant solution
-		if utils.IsClient() {
-			playerID := world.GetSingleton().PlayerID
-			if entity.GetID() != playerID {
-				continue
-			}
-		}
-
-		componentContainer := entity.GetComponentContainer()
-		physicsComponent := componentContainer.PhysicsComponent
-		transformComponent := componentContainer.TransformComponent
-
-		// calculate impulses and their decay, this is meant for controller
-		// actions that can "overwite" impulses
-		var totalImpulse mgl64.Vec3
-		for name, impulse := range physicsComponent.Impulses {
-			decayRatio := 1.0 - (impulse.ElapsedTime.Seconds() * impulse.DecayRate)
-			if decayRatio < 0 {
-				decayRatio = 0
-			}
-
-			if decayRatio < fullDecayThreshold {
-				delete(physicsComponent.Impulses, name)
-				continue
-			} else {
-				realImpulse := impulse.Vector.Mul(decayRatio)
-				totalImpulse = totalImpulse.Add(realImpulse)
-			}
-
-			// update the impulse
-			impulse.ElapsedTime = impulse.ElapsedTime + delta
-			physicsComponent.Impulses[name] = impulse
-		}
-
-		// calculate velocity adjusted by acceleration
-		totalAcceleration := accelerationDueToGravity
-		physicsComponent.Velocity = physicsComponent.Velocity.Add(totalAcceleration.Mul(delta.Seconds()))
-
-		velocity := physicsComponent.Velocity.Add(totalImpulse)
-		newPos := transformComponent.Position.Add(velocity.Mul(delta.Seconds()))
-
-		// temporary hack to not fall through the ground
-		if newPos[1] < 0 {
-			newPos[1] = 0
-			velocity[1] = 0
-			physicsComponent.Velocity[1] = 0
-		}
-
-		transformComponent.Position = newPos
-
-		// updating orientation along velocity
-		velocityWithoutY := mgl64.Vec3{velocity[0], 0, velocity[2]}
-		if !libutils.Vec3IsZero(velocityWithoutY) {
-			// Note, this will bug out if we look directly up or directly down. This
-			// is due to issues looking at objects that are along our "up" vector.
-			// I believe this is due to us losing sense of what a "right" vector is.
-			// This code will likely change when we do animation blending in the animator
-			transformComponent.Orientation = libutils.QuatLookAt(mgl64.Vec3{0, 0, 0}, velocityWithoutY.Normalize(), mgl64.Vec3{0, 1, 0})
-		}
-
-		// if entity.GetID() == 70000 {
-		// 	fmt.Printf("[CF:%d] POST PHYSICS %v\n", world.GetSingleton().CommandFrame, transformComponent.Position)
-		// }
-	}
+	physutils.PhysicsStep(delta, s.entities, s.world.GetSingleton().PlayerID)
 }

--- a/kito/utils/controllerutils/controllerutils.go
+++ b/kito/utils/controllerutils/controllerutils.go
@@ -1,0 +1,56 @@
+package controllerutils
+
+import (
+	"github.com/go-gl/mathgl/mgl64"
+	"github.com/kkevinchou/kito/kito/entities"
+	"github.com/kkevinchou/kito/kito/systems/common"
+	"github.com/kkevinchou/kito/kito/types"
+	"github.com/kkevinchou/kito/lib/input"
+	"github.com/kkevinchou/kito/lib/libutils"
+)
+
+func UpdateCharacterController(entity entities.Entity, camera entities.Entity, frameInput input.Input) {
+	componentContainer := entity.GetComponentContainer()
+	physicsComponent := componentContainer.PhysicsComponent
+
+	keyboardInput := frameInput.KeyboardInput
+
+	controlVector := common.GetControlVector(keyboardInput)
+
+	forwardVector := mgl64.Vec3{0, 0, -1}
+	rightVector := mgl64.Vec3{1, 0, 0}
+
+	if tpcComponent := componentContainer.ThirdPersonControllerComponent; tpcComponent != nil {
+		cameraComponentContainer := camera.GetComponentContainer()
+
+		forwardVector = cameraComponentContainer.TransformComponent.Orientation.Rotate(forwardVector)
+		forwardVector[1] = 0
+		forwardVector = forwardVector.Normalize()
+
+		rightVector = cameraComponentContainer.TransformComponent.Orientation.Rotate(rightVector)
+		rightVector[1] = 0
+		rightVector.Normalize()
+	}
+
+	forwardVector = forwardVector.Mul(controlVector.Z())
+	rightVector = rightVector.Mul(controlVector.X())
+	movementVector := forwardVector.Add(rightVector)
+	var moveSpeed float64 = 100
+
+	if !libutils.Vec3IsZero(movementVector) {
+		normalizedMovementVector := movementVector.Normalize()
+		impulse := types.Impulse{
+			Vector:    normalizedMovementVector.Mul(moveSpeed),
+			DecayRate: 5,
+		}
+		physicsComponent.ApplyImpulse("controllerMove", impulse)
+	}
+
+	if controlVector.Y() > 0 {
+		impulse := types.Impulse{
+			Vector:    mgl64.Vec3{0, 100, 0},
+			DecayRate: 1,
+		}
+		physicsComponent.ApplyImpulse("jumper", impulse)
+	}
+}

--- a/kito/utils/physutils/physutils.go
+++ b/kito/utils/physutils/physutils.go
@@ -74,9 +74,5 @@ func PhysicsStep(delta time.Duration, entities []entities.Entity, playerID int) 
 			// This code will likely change when we do animation blending in the animator
 			transformComponent.Orientation = libutils.QuatLookAt(mgl64.Vec3{0, 0, 0}, velocityWithoutY.Normalize(), mgl64.Vec3{0, 1, 0})
 		}
-
-		// if entity.GetID() == 70000 {
-		// 	fmt.Printf("[CF:%d] POST PHYSICS %v\n", world.GetSingleton().CommandFrame, transformComponent.Position)
-		// }
 	}
 }

--- a/kito/utils/physutils/physutils.go
+++ b/kito/utils/physutils/physutils.go
@@ -1,0 +1,82 @@
+package physutils
+
+import (
+	"time"
+
+	"github.com/go-gl/mathgl/mgl64"
+	"github.com/kkevinchou/kito/kito/entities"
+	"github.com/kkevinchou/kito/kito/utils"
+	"github.com/kkevinchou/kito/lib/libutils"
+)
+
+const (
+	fullDecayThreshold = float64(0.05)
+	gravity            = float64(60)
+)
+
+func PhysicsStep(delta time.Duration, entities []entities.Entity, playerID int) {
+	accelerationDueToGravity := mgl64.Vec3{0, -gravity, 0}
+
+	for _, entity := range entities {
+		// TODO: I don't like this here, probably a more elegant solution
+		if utils.IsClient() && entity.GetID() != playerID {
+			continue
+		}
+
+		componentContainer := entity.GetComponentContainer()
+		physicsComponent := componentContainer.PhysicsComponent
+		transformComponent := componentContainer.TransformComponent
+
+		// calculate impulses and their decay, this is meant for controller
+		// actions that can "overwite" impulses
+		var totalImpulse mgl64.Vec3
+		for name, impulse := range physicsComponent.Impulses {
+			decayRatio := 1.0 - (impulse.ElapsedTime.Seconds() * impulse.DecayRate)
+			if decayRatio < 0 {
+				decayRatio = 0
+			}
+
+			if decayRatio < fullDecayThreshold {
+				delete(physicsComponent.Impulses, name)
+				continue
+			} else {
+				realImpulse := impulse.Vector.Mul(decayRatio)
+				totalImpulse = totalImpulse.Add(realImpulse)
+			}
+
+			// update the impulse
+			impulse.ElapsedTime = impulse.ElapsedTime + delta
+			physicsComponent.Impulses[name] = impulse
+		}
+
+		// calculate velocity adjusted by acceleration
+		totalAcceleration := accelerationDueToGravity
+		physicsComponent.Velocity = physicsComponent.Velocity.Add(totalAcceleration.Mul(delta.Seconds()))
+
+		velocity := physicsComponent.Velocity.Add(totalImpulse)
+		newPos := transformComponent.Position.Add(velocity.Mul(delta.Seconds()))
+
+		// temporary hack to not fall through the ground
+		if newPos[1] < 0 {
+			newPos[1] = 0
+			velocity[1] = 0
+			physicsComponent.Velocity[1] = 0
+		}
+
+		transformComponent.Position = newPos
+
+		// updating orientation along velocity
+		velocityWithoutY := mgl64.Vec3{velocity[0], 0, velocity[2]}
+		if !libutils.Vec3IsZero(velocityWithoutY) {
+			// Note, this will bug out if we look directly up or directly down. This
+			// is due to issues looking at objects that are along our "up" vector.
+			// I believe this is due to us losing sense of what a "right" vector is.
+			// This code will likely change when we do animation blending in the animator
+			transformComponent.Orientation = libutils.QuatLookAt(mgl64.Vec3{0, 0, 0}, velocityWithoutY.Normalize(), mgl64.Vec3{0, 1, 0})
+		}
+
+		// if entity.GetID() == 70000 {
+		// 	fmt.Printf("[CF:%d] POST PHYSICS %v\n", world.GetSingleton().CommandFrame, transformComponent.Position)
+		// }
+	}
+}


### PR DESCRIPTION
When we miss the client-side prediction, we set the player's state to the snapshot state. what's important to note is that the snapshot state is in the past! At the very least, a whole RTT in the past. So, we want to replay our historical inputs to catch up to the player's present.